### PR TITLE
PHP7 Xdebug take 2

### DIFF
--- a/.docker/php7-cli/Dockerfile
+++ b/.docker/php7-cli/Dockerfile
@@ -134,7 +134,7 @@ RUN chmod +x /opt/startup.sh
 # Starter script
 ENTRYPOINT ["/opt/startup.sh"]
 
-ENV PHP_INI_SCAN_DIR="/etc/php/7.0/cli/conf.d:/var/www/.docker/etc/php"
+ENV PHP_INI_SCAN_DIR="/etc/php/7.0/cli/conf.d:/var/www/src/docker/etc/php"
 
 # By default, launch supervisord to keep the container running.
 CMD /usr/bin/supervisord -n

--- a/.docker/php7-cli/Dockerfile
+++ b/.docker/php7-cli/Dockerfile
@@ -45,6 +45,9 @@ RUN apt-get install -y \
   php-cli \
   php-mcrypt
 
+# Disable loading of xdebug.so
+RUN rm -f /etc/php/7.0/cli/conf.d/20-xdebug.ini
+
 # Install AWS CLI
 RUN apt-get install -y awscli
 
@@ -101,9 +104,6 @@ RUN phpcs --config-set default_standard Drupal
 
 # Add local settings
 COPY php-cli.ini /etc/php/7.0/cli/conf.d/z_php.ini
-# Add xdebug settins. These are moved when `ahoy docker xdebug start` is run.
-COPY xdebug-linux.ini /etc/php5/xdebug-linux.ini
-COPY xdebug-macos.ini /etc/php5/xdebug-macos.ini
 
 # Add git completion for the cli
 RUN curl -o ~/.git-completion.bash https://raw.githubusercontent.com/git/git/master/contrib/completion/git-completion.bash
@@ -133,6 +133,8 @@ RUN chmod +x /opt/startup.sh
 
 # Starter script
 ENTRYPOINT ["/opt/startup.sh"]
+
+ENV PHP_INI_SCAN_DIR="/etc/php/7.0/cli/conf.d:/var/www/.docker/etc/php"
 
 # By default, launch supervisord to keep the container running.
 CMD /usr/bin/supervisord -n

--- a/.docker/php7-cli/php-cli.ini
+++ b/.docker/php7-cli/php-cli.ini
@@ -3,17 +3,6 @@
 ; Maximum amount of memory a script may consume
 memory_limit = -1 
 
-[xdebug]
-xdebug_remote_handler=dbgp
-xdebug.remote_port=9000
-xdebug.remote_log="/var/log/xdebug.log"
-xdebug.idekey="PHPSTORM"
-xdebug.show_local_vars=On
-xdebug.var_display_max_data=10000
-xdebug.var_display_max_depth=20
-xdebug.max_nesting_level=256
-xdebug.extended_info=On
-
 [opcache]
 opcache.enable=1
 opcache.enable_cli=1

--- a/.docker/php7-cli/xdebug-linux.ini
+++ b/.docker/php7-cli/xdebug-linux.ini
@@ -1,5 +1,0 @@
-[xdebug]
-xdebug.default_enable=On
-xdebug.remote_enable=On
-xdebug.remote_connect_back=1
-xdebug.remote_autostart=1

--- a/.docker/php7-cli/xdebug-macos.ini
+++ b/.docker/php7-cli/xdebug-macos.ini
@@ -1,6 +1,0 @@
-[xdebug]
-xdebug.default_enable=On
-xdebug.remote_enable=On
-xdebug.remote_host=docker.for.mac.localhost
-xdebug.remote_connect_back=0
-xdebug.remote_autostart=1

--- a/.docker/php7-web/Dockerfile
+++ b/.docker/php7-web/Dockerfile
@@ -1,22 +1,25 @@
 FROM ubuntu:18.04
 
-RUN apt update && apt-get update && apt install apache2 -y && \
-    DEBIAN_FRONTEND=noninteractive apt install php libapache2-mod-php -y && \
+RUN apt-get update && apt-get update && apt-get install apache2 -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install php libapache2-mod-php -y && \
     apt-get install -y software-properties-common && \
     add-apt-repository ppa:ondrej/php && \
-    DEBIAN_FRONTEND=noninteractive apt install php7.1 -y && \
-    DEBIAN_FRONTEND=noninteractive apt install php7.1-dev php7.1-cli php7.1-common php7.1-curl php7.1-gd php7.1-json php7.1-opcache php7.1-mysql php7.1-mbstring php7.1-mcrypt php7.1-zip php7.1-xml -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install php7.1 -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install php7.1-dev php7.1-cli php7.1-common php7.1-curl php7.1-gd php7.1-json php7.1-opcache php7.1-mysql php7.1-mbstring php7.1-mcrypt php7.1-zip php7.1-xml php7.1-xdebug -y
 
-    a2enmod rewrite && \
+# Disable loading of xdebug.so
+RUN rm -f /etc/php/7.1/cli/conf.d/20-xdebug.ini && \
+    rm -f /etc/php/7.1/apache2/conf.d/20-xdebug.ini
+
+RUN a2enmod rewrite && \
     a2dismod php7.2 && \
-    a2enmod php7.1 && \
+    a2enmod php7.1
 
-    update-alternatives --set php /usr/bin/php7.1 && \
+RUN update-alternatives --set php /usr/bin/php7.1 && \
     update-alternatives --set phar /usr/bin/phar7.1 && \
     update-alternatives --set phar.phar /usr/bin/phar.phar7.1 && \
     update-alternatives --set phpize /usr/bin/phpize7.1 && \
     update-alternatives --set php-config /usr/bin/php-config7.1 && \
-
     a2enmod ssl && \
     a2ensite default-ssl
 
@@ -24,5 +27,7 @@ COPY 000-default.conf /etc/apache2/sites-available/000-default.conf
 COPY default-ssl.conf /etc/apache2/sites-available/default-ssl.conf
 
 EXPOSE 80 443
+
+ENV PHP_INI_SCAN_DIR="/etc/php/7.1/apache2/conf.d:/var/www/.docker/etc/php"
 
 CMD ["/usr/sbin/apache2ctl", "-D", "FOREGROUND"]

--- a/.docker/php7-web/Dockerfile
+++ b/.docker/php7-web/Dockerfile
@@ -28,6 +28,6 @@ COPY default-ssl.conf /etc/apache2/sites-available/default-ssl.conf
 
 EXPOSE 80 443
 
-ENV PHP_INI_SCAN_DIR="/etc/php/7.1/apache2/conf.d:/var/www/.docker/etc/php"
+ENV PHP_INI_SCAN_DIR="/etc/php/7.1/apache2/conf.d:/var/www/src/docker/etc/php"
 
 CMD ["/usr/sbin/apache2ctl", "-D", "FOREGROUND"]


### PR DESCRIPTION
This tweaks the php config so that we can easily add or remove xdebug. Very similar to #10 but instead of scanning .docker (which was mapped in from dktl application route) for xdebug.ini we're scanning in /src per-project.

This essentially just removes the main xdebug.ini file after build, so that unless an xdebug.ini is added to _src/docker/etc/php_, xdebug will not be loaded.

If you want to test this locally, try building the web image by going to _.docker/php7-web_ and running `docker build -t dkan_web_test .`, then replacing the web image in docker-compose-common.yml to `dkan_web_test`.