### PR TITLE
Add xdebug extension on new PHP 7.2 web image

### DIFF
--- a/.docker/php72-web/Dockerfile
+++ b/.docker/php72-web/Dockerfile
@@ -10,7 +10,7 @@ RUN \
     apt-get update && \
     apt-get install -y software-properties-common && \
     apt-get install -y imagemagick graphicsmagick && \
-    apt-get install -y libapache2-mod-php7.2 php7.2-bcmath php7.2-bz2 php7.2-cli php7.2-common php7.2-curl php7.2-dba php7.2-gd php7.2-imap php7.2-intl php7.2-ldap php7.2-mbstring php7.2-mysql php7.2-odbc php7.2-xml php7.2-xmlrpc php7.2-xsl php7.2-zip && \
+    apt-get install -y libapache2-mod-php7.2 php7.2-bcmath php7.2-bz2 php7.2-cli php7.2-common php7.2-curl php7.2-dba php7.2-gd php7.2-imap php7.2-intl php7.2-ldap php7.2-mbstring php7.2-mysql php7.2-odbc php7.2-xml php7.2-xmlrpc php7.2-xsl php7.2-zip php7.2-xdebug && \
     apt-get install -y php-imagick
 
 # Disable loading of xdebug.so


### PR DESCRIPTION
The XDebug extension is currently missing on the PHP 7.2 web image. This PR should correct that.